### PR TITLE
Kleiner Abfrage-Fix (operator=*)

### DIFF
--- a/update_data.js
+++ b/update_data.js
@@ -104,9 +104,9 @@ const vendings = [
 let query = `
     [out:json][timeout:742];
     (
-    node[vending~"${vendings.join("|")}"][operator!~Selecta](${bbox});
-    way[vending~"${vendings.join("|")}"][operator!~Selecta](${bbox});
-    relation[vending~"${vendings.join("|")}"][operator!~Selecta](${bbox});
+    node[vending~"${vendings.join("|")}"][operator!~"[Ss]electa"](${bbox});
+    way[vending~"${vendings.join("|")}"][operator!~"[Ss]electa"](${bbox});
+    relation[vending~"${vendings.join("|")}"][operator!~"[Ss]electa"](${bbox});
 
     node[amenity=marketplace](${bbox});
     way[amenity=marketplace](${bbox});


### PR DESCRIPTION
Nur ein kleiner Fix, der mir noch hinterher eingefallen ist 😄
Falls der 'operator'-Tag den Wert **s**electa hat und nicht **S**electa wurden diese bisher trotzdem angezeigt. Das sollte jetzt behoben sein... 
Hab durch Zufall diesen Knoten hier gefunden und der hat mich dann auf die Idee gebracht 😃: https://www.openstreetmap.org/node/5713322948

EDIT: die komplette Abfrage ist nun https://overpass-turbo.eu/s/BaY