### PR TITLE
Abfrage verbessert

### DIFF
--- a/update_data.js
+++ b/update_data.js
@@ -102,22 +102,18 @@ const vendings = [
 ];
 
 let query = `
-    [out:json][timeout:742];
+    [out:json][timeout:742][bbox:${bbox}];
     (
-    node[vending~"${vendings.join("|")}"][operator!~"[Ss]electa"](${bbox});
-    way[vending~"${vendings.join("|")}"][operator!~"[Ss]electa"](${bbox});
-    relation[vending~"${vendings.join("|")}"][operator!~"[Ss]electa"](${bbox});
+      nwr[vending~"${vendings.join("|")}"][vending!=animal_food][operator!~"[Ss]electa"];
 
-    node[amenity=marketplace](${bbox});
-    way[amenity=marketplace](${bbox});
-    relation[amenity=marketplace](${bbox});
+      nwr[amenity=marketplace];
 
-    node[shop=farm](${bbox});
-    way[shop=farm](${bbox});
-    relation[shop=farm](${bbox});
+      nwr[shop=farm];
     );
     out center;
 `;
+
+fs.writeFileSync('query.json', query, 'utf-8');
 
 // query overpass, write to folders by id
 query_overpass(query, (error, data)  => {

--- a/update_data.js
+++ b/update_data.js
@@ -113,8 +113,6 @@ let query = `
     out center;
 `;
 
-fs.writeFileSync('query.json', query, 'utf-8');
-
 // query overpass, write to folders by id
 query_overpass(query, (error, data)  => {
     const farmshopGeoJsonFeatures = [];


### PR DESCRIPTION
Die Abfrage 🔍 ist nun folgende: https://overpass-turbo.eu/s/BC9
Ich habe die Abfrage mal ein bischen kürzer gemacht, weil ja sowieso immer nach `node`, `way` und `relation` gesucht werden soll. (Stattdessen funktioniert auch `nwr`)
Außerdem gibt es jetzt einen extra Check ✔️, damit keine Elemente mit `vending=animal_food` 
🐦 ausgegeben werden.