### PR TITLE
Adding translation for fast_food

### DIFF
--- a/js/popupcontent.js
+++ b/js/popupcontent.js
@@ -87,6 +87,7 @@ function popupcontent(feature, layer) {
                     .replace("butter", "Butter")
                     .replace("marketplace", "Marktplatz")
                     .replace("bread", "Brot")
+                    .replace("fast_food", "Schnellimbiss")
                     .replace("food", "Lebensmittel")
                     .replace("drinks", "Getränke")
                 + "</td></tr>");


### PR DESCRIPTION
https://www.openstreetmap.org/node/871816175
https://farmshops.eu/#51.84428,13.97268,18z
Looks a bit strange otherwise:
![image](https://user-images.githubusercontent.com/2410353/131455055-942f8a8d-5fa7-4c5d-9308-20f77dc41600.png)

The correct fix would be #14 :-)